### PR TITLE
Including http status in getStatus() response

### DIFF
--- a/NissanConnect.class.php
+++ b/NissanConnect.class.php
@@ -172,6 +172,8 @@ class NissanConnect {
 
         $result = new stdClass();
 
+        $result->status = $response2->status;
+
         $result->LastUpdated = date('Y-m-d H:i', strtotime($response->BatteryStatusRecords->OperationDateAndTime));
 
         $result->PluggedIn = ( $response->BatteryStatusRecords->PluginState != 'NOT_CONNECTED' );


### PR DESCRIPTION
For other commands, the result includes the HTTP status of the response, but this was missing from getStatus(). Adding, for a consistent interface.